### PR TITLE
fix: hardcoded Discord upload link causes describe command to fail

### DIFF
--- a/midjourney/services/discord.go
+++ b/midjourney/services/discord.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	url       = "https://discord.com/api/v9/interactions"
-	uploadUrl = "https://discord.com/api/v9/channels/1097913573247824045/attachments"
-	appId     = "936929561302675456"
+	url             = "https://discord.com/api/v9/interactions"
+	uploadUrlFormat = "https://discord.com/api/v9/channels/%s/attachments"
+	appId           = "936929561302675456"
 )
 
 func GenerateImage(prompt string) error {
@@ -171,6 +171,7 @@ func Attachments(name string, size int64) (ResAttachments, error) {
 			Id:       "1",
 		}},
 	}
+	uploadUrl := fmt.Sprintf(uploadUrlFormat, config.GetConfig().DISCORD_CHANNEL_ID)
 	body, err := request(requestBody, uploadUrl)
 	var data ResAttachments
 	json.Unmarshal(body, &data)
@@ -195,6 +196,6 @@ func request(params interface{}, url string) ([]byte, error) {
 	}
 	defer response.Body.Close()
 	bod, respErr := ioutil.ReadAll(response.Body)
-	fmt.Println("response:", string(bod), respErr, response.Status, uploadUrl)
+	fmt.Println("response:", string(bod), respErr, response.Status, url)
 	return bod, respErr
 }


### PR DESCRIPTION
## 描述

感谢开源这个项目。

看到支持 `describe` 了我就赶紧编译试用了一下，发现没反应，看日志是 Discord 上传链接写死了，

https://github.com/ConnectAI-E/Feishu-Midjourney/blob/e702ac467cd92c3395b92c83a390645f4851b088/midjourney/services/discord.go#L15

客户端直接报 `403`，所以我改了一下。其实这个 `uploadUrlFormat` 似乎没必要放到 const 里，如果以后有别的类似接口可能改成 baseUrl 的比较合适，我不了解 Discord 的接口以及这个项目后续的开发计划，因此也就这样写了。看作者选择吧。

```log
1|feishu-midjourney-lark  | 2023/05/07 11:34:55 [Error] [handle event,path:/webhook/event,error:event type: message, not found handler]
1|feishu-midjourney-lark  | [GIN] 2023/05/07 - 11:34:55 | 200 |  160.434213ms |   123.123.123.123 | POST     "/webhook/event"
2|feishu-midjourney-midjourney  | response: {"message": "Missing Access", "code": 50001} <nil> 403 Forbidden https://discord.com/api/v9/channels/1097913573247824045/attachments
2|feishu-midjourney-midjourney  | [GIN] 2023/05/07 - 11:34:57 | 500 |  166.750993ms |       127.0.0.1 | POST     "/v1/trigger/upload"
1|feishu-midjourney-lark        | 2023/05/07 11:34:57 [Error] [handle event,path:/webhook/event, error:interface conversion: interface {} is nil, not string]
1|feishu-midjourney-lark        | [GIN] 2023/05/07 - 11:34:57 | 500 |  1.403973418s |   123.123.123.123 | POST     "/webhook/event"
```

顺手我把 `request` 函数里的 log 给改成了 `url`，主要是没看出来打印 `uploadUrl` 的用意是什么。

https://github.com/ConnectAI-E/Feishu-Midjourney/blob/e702ac467cd92c3395b92c83a390645f4851b088/midjourney/services/discord.go#L198

如果不符合要求请随意关闭这个 PR 即可。