### PR TITLE
feat: 增加 docker-compose 部署方案

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  lark:
+    build: ./lark
+    ports:
+      - "16008:16008"
+    environment:
+      - GIN_MODE=release
+      - APP_ID=your_lark_app_id
+      - APP_SECRET=your_lark_app_secret
+      - APP_ENCRYPT_KEY=your_lark_encrypt_key
+      - APP_VERIFICATION_TOKEN=your_lark_verification_token
+      - BOT_NAME=your_bot_name
+      - DISCORD_MIDJOURNEY_URL=http://midjourney:16007/v1/trigger/midjourney-proxy-bot
+      - DISCORD_UPLOAD_URL=http://midjourney:16007/v1/trigger/upload
+    restart: unless-stopped
+  midjourney:
+    build: ./midjourney
+    environment:
+      - GIN_MODE=release
+      - DISCORD_USER_TOKEN=your_discord_user_token
+      - DISCORD_BOT_TOKEN=your_discord_bot_token
+      - DISCORD_SERVER_ID=your_discord_server_id
+      - DISCORD_CHANNEL_ID=your_discord_channel_id
+      - CB_URL=http://lark:16008/api/discord
+    restart: unless-stopped

--- a/lark/Dockerfile
+++ b/lark/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.20 AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN go mod download
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /lark
+
+FROM gcr.io/distroless/base-debian11
+
+WORKDIR /
+
+COPY --from=build lark lark
+
+EXPOSE 16008 
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/lark"]

--- a/midjourney/Dockerfile
+++ b/midjourney/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.20 AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN go mod download
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /midjourney
+
+FROM gcr.io/distroless/base-debian11
+
+WORKDIR /
+
+COPY --from=build midjourney midjourney
+
+EXPOSE 16007
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/midjourney"]


### PR DESCRIPTION
## 描述
增加 `Dockerfile` 以及 `docker-compose.yaml`，这样的话，配置好 `docker-compose.yaml` 中的环境变量之后，使用
```bash
docker-compose up -d 
```
即可以一键部署 #5 
