### PR TITLE
Update config.go with the right default MJ port 16007[FIX]

### DIFF
--- a/midjourney/initialization/config.go
+++ b/midjourney/initialization/config.go
@@ -27,7 +27,7 @@ func LoadConfig(cfg string) *Config {
 		DISCORD_SERVER_ID:  getViperStringValue("DISCORD_SERVER_ID"),
 		DISCORD_CHANNEL_ID: getViperStringValue("DISCORD_CHANNEL_ID"),
 		CB_URL:             getViperStringValue("CB_URL"),
-		MJ_PORT:            getDefaultValue("MJ_PORT", "16008"),
+		MJ_PORT:            getDefaultValue("MJ_PORT", "16007"),
 	}
 	return config
 }


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
直接利用 docker compose up 启动服务，会出现错误；
修改默认的MJ端口能解决这个问题

## 相关问题
- [#31 ]（[问题链接](https://github.com/ConnectAI-E/Feishu-Midjourney/issues/31)）
